### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: php
-dist: trusty
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
-  - 'hhvm'
+  - '7.2'
+  - '7.3'
+  - '7.4'
+  - 'nightly'
+matrix:
+  allow_failures:
+    - php: nightly
 install:
-  - composer update
+  - composer install
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,22 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "fzaninotto/faker": "^1.6",
-        "satooshi/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "files": [
             "src/Functions.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "DivineOmega\\ObjectToArray\\Tests\\": "tests/Unit/"
+        }
+    },
     "license": "LGPL-3.0-only",
     "require": {
+        "php": ">=7.1"
     }
 }

--- a/tests/Unit/ObjectToArrayTest.php
+++ b/tests/Unit/ObjectToArrayTest.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace DivineOmega\ObjectToArray\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 class ObjectToArrayTest extends TestCase
 {
     public function testBasicUsage()
     {
-        $object = new stdClass();
+        $object = new \stdClass();
         $object->name = 'John';
         $object->age = 32;
 
@@ -20,10 +22,10 @@ class ObjectToArrayTest extends TestCase
 
     public function testNested()
     {
-        $object = new stdClass();
+        $object = new \stdClass();
         $object->name = 'John';
         $object->age = 32;
-        $object->pet = new stdClass();
+        $object->pet = new \stdClass();
         $object->pet->type = 'cat';
         $object->pet->name = 'Mr Fluffkins The Third';
 
@@ -41,7 +43,7 @@ class ObjectToArrayTest extends TestCase
 
     public function testArray()
     {
-        $object = new stdClass();
+        $object = new \stdClass();
         $object->name = 'John';
         $object->age = 32;
         $object->favouriteFoods = [


### PR DESCRIPTION
# Changed log
- Add minimum `php-7.1` version requirement for this package.
- Add `php-7.2` to `php-7.4` version tests on Travis CI build.
- Add `DivineOmega\\ObjectToArray\\Tests\\"` namespace to load test classes automatically.
- Using/Defining the PHPUnit `^7.0 || ^8.0` versions to support different PHP versions.
- This `satooshi/php-coveralls` package is deprecated. Using the `php-coveralls/php-coveralls` package instead.
- The `composer install` command is fined on Travis CI build because the `composer.lock` is not under Git version control.