### PR TITLE
Remove StyleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 [![Build Status](https://travis-ci.org/Jord-JD/object_to_array.svg?branch=master)](https://travis-ci.org/Jord-JD/object_to_array)
 [![Coverage Status](https://coveralls.io/repos/github/Jord-JD/object_to_array/badge.svg?branch=master)](https://coveralls.io/github/Jord-JD/object_to_array?branch=master)
-[![StyleCI](https://styleci.io/repos/121260505/shield?branch=master)](https://styleci.io/repos/121260505)
 
 This PHP package provides an `object_to_array` helper function. You can use this function to convert an object to an array.
 


### PR DESCRIPTION
Removes the obsolete StyleCI badge. StyleCI is no longer part of the maintenance workflow.